### PR TITLE
Excutor of searchFacebookFriends should be "dataOptionalExecutor"

### DIFF
--- a/commonjs/src/sdk/cloudapi.js
+++ b/commonjs/src/sdk/cloudapi.js
@@ -373,7 +373,7 @@ BedFrame.build(Cloud, {
                 { method: 'externalAccountLink', restMethod: 'external_account_link', verb: 'POST' },
                 { method: 'externalAccountUnlink', restMethod: 'external_account_unlink', verb: 'DELETE' },
                 { method: 'searchFacebookFriends', restNamespace: 'social', restMethod: 'facebook/search_friends',
-                    executor: dataExcludedExecutor
+                    executor: dataOptionalExecutor
                 }
             ]
         },


### PR DESCRIPTION
searchFacebookFriends return only 10 results without per_page.
"https://api.cloud.appcelerator.com/v1/social/facebook/search_friends.json" with per_page works properly. Why don't you change to "dataOptionalExecutor"?